### PR TITLE
remove builtin `DOM` lib from tsconfig, use `duplex` property to stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
       }
     }
   },
-  "files": ["src/", "dist/"],
+  "files": ["dist/"],
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
     "@types/express": ">=4.0.0, <5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,11 @@ function fromERequest(req: ERequest): Request {
   return new Request(url, {
     method: req.method,
     headers,
+    duplex: "half",
     body:
       req.method === "GET" || req.method === "HEAD"
         ? undefined
-        : (Readable.toWeb(req) as ReadableStream<Uint8Array>),
+        : (Readable.toWeb(req)),
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
remove builtin `DOM` lib from tsconfig because it should refer `@types/node`

use `duplex` property to stream, [if we don't explicit set this error occurs](https://github.com/nodejs/node/issues/46221)
